### PR TITLE
Restore server environment setting and remove debug conditionals

### DIFF
--- a/TrackNerd/Models/AppConfiguration.swift
+++ b/TrackNerd/Models/AppConfiguration.swift
@@ -89,11 +89,7 @@ struct AppConfiguration {
 
 extension AppConfiguration {
     static var isDebugBuild: Bool {
-        #if DEBUG
         return true
-        #else
-        return false
-        #endif
     }
     
     static var appVersion: String {

--- a/TrackNerd/Models/AppSettings.swift
+++ b/TrackNerd/Models/AppSettings.swift
@@ -38,8 +38,8 @@ class AppSettings {
     // MARK: - Server Settings
     var useProductionServer: Bool {
         get {
-            // Default to production server in release builds, dev server in debug builds
-            let defaultValue = !AppConfiguration.isDebugBuild
+            // Default to production server
+            let defaultValue = true
             return userDefaults.object(forKey: Keys.useProductionServer) as? Bool ?? defaultValue
         }
         set {

--- a/TrackNerd/Views/ListeningView.swift
+++ b/TrackNerd/Views/ListeningView.swift
@@ -40,7 +40,6 @@ struct ListeningView: View {
                             .multilineTextAlignment(.center)
                         
                         // Debug info display
-                        #if DEBUG
                         if showDebugInfo {
                             Text("Sample Duration: \(AppSettings.formatDuration(sampleDuration))")
                                 .musicNerdStyle(.caption(color: Color.MusicNerd.textSecondary))
@@ -50,7 +49,6 @@ struct ListeningView: View {
                                 .cornerRadius(CGFloat.BorderRadius.xs)
                                 .accessibilityIdentifier("debug-sample-duration")
                         }
-                        #endif
                     }
                     .padding(.top, CGFloat.MusicNerd.xl)
                     

--- a/TrackNerd/Views/SettingsView.swift
+++ b/TrackNerd/Views/SettingsView.swift
@@ -222,8 +222,7 @@ struct SettingsView: View {
                         .musicNerdStyle(.titleSmall(color: Color.MusicNerd.textSecondary))
                 }
                 
-                // Debug Section (only in debug builds)
-                #if DEBUG
+                // Debug Section
                 Section {
                     HStack {
                         Image(systemName: "info.circle")
@@ -298,7 +297,6 @@ struct SettingsView: View {
                     Text("Debug")
                         .musicNerdStyle(.titleSmall(color: Color.MusicNerd.textSecondary))
                 }
-                #endif
             }
             .listStyle(InsetGroupedListStyle())
             .background(Color.MusicNerd.background)


### PR DESCRIPTION
## Summary
- Restore the server environment setting that was previously lost
- Remove `#if DEBUG` conditionals to make all debug features accessible
- Set server setting to default to production MusicNerd server

## Changes Made
- **SettingsView**: Made server toggle always visible (removed from debug-only section)
- **AppSettings**: Changed default server to production instead of debug-build dependent
- **ListeningView**: Made debug info display available in all builds
- **AppConfiguration**: Simplified `isDebugBuild` to always return true

## Test Plan
- [x] Unit tests pass
- [x] Server setting appears in Settings UI
- [x] Toggle switches between production (api.musicnerd.xyz) and development (localhost:3000)
- [x] Setting defaults to production server
- [x] Debug features accessible in all builds

🤖 Generated with [Claude Code](https://claude.ai/code)