### PR TITLE
Phase 7: Apple Music preview playback – main-thread publishing and UI binding

### DIFF
--- a/TrackNerd.xcodeproj/project.pbxproj
+++ b/TrackNerd.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 				INFOPLIST_FILE = TrackNerd/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Music Nerd ID";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Music Nsrd ID uses Apple Music to play previews or full tracks of songs you recognize.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Music Nerd ID needs microphone access to listen to music and identify songs using Shazam technology.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -504,6 +505,7 @@
 				INFOPLIST_FILE = TrackNerd/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Music Nerd ID";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Music Nsrd ID uses Apple Music to play previews or full tracks of songs you recognize.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Music Nerd ID needs microphone access to listen to music and identify songs using Shazam technology.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TrackNerd/Services/AppleMusicService.swift
+++ b/TrackNerd/Services/AppleMusicService.swift
@@ -3,6 +3,7 @@ import MusicKit
 import Combine
 import AVFoundation
 
+@MainActor
 protocol AppleMusicServiceProtocol: AnyObject {
     func requestAuthorization() async -> MusicAuthorization.Status
     var authorizationStatus: MusicAuthorization.Status { get }
@@ -15,8 +16,10 @@ protocol AppleMusicServiceProtocol: AnyObject {
     func playPreview(url: URL)
     func pause()
     func resume()
+    var isPlayingPreview: Bool { get }
 }
 
+@MainActor
 final class AppleMusicService: AppleMusicServiceProtocol, ObservableObject {
     @Published private(set) var authorizationStatus: MusicAuthorization.Status = MusicAuthorization.currentStatus
     private var cancellables: Set<AnyCancellable> = []

--- a/TrackNerd/Services/AppleMusicService.swift
+++ b/TrackNerd/Services/AppleMusicService.swift
@@ -1,0 +1,34 @@
+import Foundation
+import MusicKit
+import Combine
+
+protocol AppleMusicServiceProtocol: AnyObject {
+    func requestAuthorization() async -> MusicAuthorization.Status
+    var authorizationStatus: MusicAuthorization.Status { get }
+    func currentSubscription() async -> MusicSubscription?
+}
+
+final class AppleMusicService: AppleMusicServiceProtocol, ObservableObject {
+    @Published private(set) var authorizationStatus: MusicAuthorization.Status = MusicAuthorization.currentStatus
+    private var cancellables: Set<AnyCancellable> = []
+
+    func requestAuthorization() async -> MusicAuthorization.Status {
+        // If already determined, return current status
+        let current = MusicAuthorization.currentStatus
+        if current != .notDetermined {
+            authorizationStatus = current
+            return current
+        }
+        let status = await MusicAuthorization.request()
+        authorizationStatus = status
+        return status
+    }
+
+    func currentSubscription() async -> MusicSubscription? {
+        do {
+            return try await MusicSubscription.current
+        } catch {
+            return nil
+        }
+    }
+}

--- a/TrackNerd/Services/AppleMusicService.swift
+++ b/TrackNerd/Services/AppleMusicService.swift
@@ -1,16 +1,26 @@
 import Foundation
 import MusicKit
 import Combine
+import AVFoundation
 
 protocol AppleMusicServiceProtocol: AnyObject {
     func requestAuthorization() async -> MusicAuthorization.Status
     var authorizationStatus: MusicAuthorization.Status { get }
     func currentSubscription() async -> MusicSubscription?
+    // Lookup helpers
+    func song(fromAppleMusicID id: String) async -> Song?
+    func searchSong(title: String, artist: String) async -> Song?
+    func previewURL(for song: Song) -> URL?
+    // Preview playback controls
+    func playPreview(url: URL)
+    func pause()
+    func resume()
 }
 
 final class AppleMusicService: AppleMusicServiceProtocol, ObservableObject {
     @Published private(set) var authorizationStatus: MusicAuthorization.Status = MusicAuthorization.currentStatus
     private var cancellables: Set<AnyCancellable> = []
+    private var player: AVPlayer?
 
     func requestAuthorization() async -> MusicAuthorization.Status {
         // If already determined, return current status
@@ -30,5 +40,52 @@ final class AppleMusicService: AppleMusicServiceProtocol, ObservableObject {
         } catch {
             return nil
         }
+    }
+
+    // MARK: - Lookup
+    func song(fromAppleMusicID id: String) async -> Song? {
+        do {
+            let musicId = MusicItemID(rawValue: id)
+            let request = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: musicId)
+            let response = try await request.response()
+            return response.items.first
+        } catch {
+            return nil
+        }
+    }
+
+    func searchSong(title: String, artist: String) async -> Song? {
+        do {
+            let term = "\(title) \(artist)"
+            var request = MusicCatalogSearchRequest(term: term, types: [Song.self])
+            request.limit = 5
+            let response = try await request.response()
+            return response.songs.first
+        } catch {
+            return nil
+        }
+    }
+
+    func previewURL(for song: Song) -> URL? {
+        // Prefer the first available preview asset
+        return song.previewAssets?.first?.url
+    }
+
+    // MARK: - Preview Playback
+    func playPreview(url: URL) {
+        player?.pause()
+        player = AVPlayer(url: url)
+        // Ensure playback category is correct for preview
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
+        try? AVAudioSession.sharedInstance().setActive(true)
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
+    func resume() {
+        player?.play()
     }
 }

--- a/TrackNerd/Services/Container.swift
+++ b/TrackNerd/Services/Container.swift
@@ -50,7 +50,12 @@ final class DefaultServiceContainer: ServiceContainer, ObservableObject {
         modelContext: Container.shared.modelContainer.mainContext
     )
     lazy var permissionService: PermissionServiceProtocol = PermissionService()
-    lazy var appleMusicService: AppleMusicServiceProtocol = AppleMusicService()
+    // Store a concrete instance for SwiftUI environment injection
+    private lazy var _appleMusicServiceObject = AppleMusicService()
+    // Expose protocol-typed service for general use
+    lazy var appleMusicService: AppleMusicServiceProtocol = _appleMusicServiceObject
+    // Expose concrete type for EnvironmentObject injection
+    var appleMusicServiceObject: AppleMusicService { _appleMusicServiceObject }
     
     private init() {}
 }

--- a/TrackNerd/Services/Container.swift
+++ b/TrackNerd/Services/Container.swift
@@ -36,6 +36,7 @@ protocol ServiceContainer {
     var musicNerdService: MusicNerdServiceProtocol { get }
     var storageService: StorageServiceProtocol { get }
     var permissionService: PermissionServiceProtocol { get }
+    var appleMusicService: AppleMusicServiceProtocol { get }
 }
 
 @MainActor
@@ -49,6 +50,7 @@ final class DefaultServiceContainer: ServiceContainer, ObservableObject {
         modelContext: Container.shared.modelContainer.mainContext
     )
     lazy var permissionService: PermissionServiceProtocol = PermissionService()
+    lazy var appleMusicService: AppleMusicServiceProtocol = AppleMusicService()
     
     private init() {}
 }

--- a/TrackNerd/TrackNerdApp.swift
+++ b/TrackNerd/TrackNerdApp.swift
@@ -24,6 +24,7 @@ struct TrackNerdApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(DefaultServiceContainer.shared)
         }
         .modelContainer(for: [SongMatch.self, EnrichmentData.self, EnrichmentCacheEntry.self])
     }

--- a/TrackNerd/TrackNerdApp.swift
+++ b/TrackNerd/TrackNerdApp.swift
@@ -25,6 +25,7 @@ struct TrackNerdApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(DefaultServiceContainer.shared)
+                .environmentObject(DefaultServiceContainer.shared.appleMusicServiceObject)
         }
         .modelContainer(for: [SongMatch.self, EnrichmentData.self, EnrichmentCacheEntry.self])
     }

--- a/TrackNerd/Views/MatchDetailView.swift
+++ b/TrackNerd/Views/MatchDetailView.swift
@@ -109,12 +109,7 @@ struct MatchDetailView: View {
                     size: .medium
                 )
                 
-                MusicNerdButton(
-                    title: "Resume",
-                    action: { services.appleMusicService.resume() },
-                    style: .outline,
-                    size: .medium
-                )
+                // Removed Resume button (not needed)
             }
             .padding(.top, CGFloat.MusicNerd.sm)
         }

--- a/TrackNerd/Views/MatchDetailView.swift
+++ b/TrackNerd/Views/MatchDetailView.swift
@@ -15,6 +15,7 @@ struct MatchDetailView: View {
     @State private var isRetrying = false
     @State private var retryCount = 0
     @EnvironmentObject private var services: DefaultServiceContainer
+    @EnvironmentObject private var appleMusic: AppleMusicService
     
     var body: some View {
         NavigationView {
@@ -96,15 +97,21 @@ struct MatchDetailView: View {
         VStack(spacing: CGFloat.MusicNerd.sm) {
             HStack(spacing: CGFloat.MusicNerd.sm) {
                 MusicNerdButton(
-                    title: "Play Preview",
-                    action: { Task { await playPreview() } },
+                    title: appleMusic.isPlayingPreview ? "Pause" : "Play Preview",
+                    action: {
+                        if appleMusic.isPlayingPreview {
+                            services.appleMusicService.pause()
+                        } else {
+                            Task { await playPreview() }
+                        }
+                    },
                     style: .primary,
                     size: .medium
                 )
                 
                 MusicNerdButton(
-                    title: "Pause",
-                    action: { services.appleMusicService.pause() },
+                    title: "Resume",
+                    action: { services.appleMusicService.resume() },
                     style: .outline,
                     size: .medium
                 )

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -253,8 +253,8 @@ Build an iOS app under the Music Nerd brand that:
   - [x] Enable Background Modes > Audio and AirPlay.
   - [x] Implement MusicKit authorization flow using `MusicAuthorization`.
 
-- [ ] **Apple Music Service Layer**:
-  - [ ] Create `AppleMusicService` with MusicKit integration providing:
+- [x] **Apple Music Service Layer**:
+  - [x] Create `AppleMusicService` with MusicKit integration providing:
     - [x] `requestAuthorization() -> MusicAuthorization.Status`
     - [x] `currentSubscription() -> MusicSubscription?`
     - [x] `song(fromAppleMusicID:) async throws -> Song?`
@@ -263,6 +263,7 @@ Build an iOS app under the Music Nerd brand that:
     - [x] Playback control: `playPreview(url:)`, `pause()`, `resume()`
     - [ ] Playback control: `playFull(song:)`, `seek(to:)`
     - [ ] Observable playback state (isPlaying, position, duration, source: preview/full, current item)
+    - [x] Publish `isPlayingPreview` for preview play/pause UI
   - [ ] Handle authorization states (denied, authorized, restricted) and subscription capability.
 
 - [ ] **Playback Implementation**:
@@ -271,6 +272,7 @@ Build an iOS app under the Music Nerd brand that:
     - [x] Implement 30‑second preview playback with `AVPlayer` (auto‑stop at 30s).
     - [ ] Handle DRM‑free preview audio streams and errors.
     - [x] Preview controls: play/pause (seek optional - deferred).
+    - [x] SwiftUI binding to live playback state via `@EnvironmentObject` service
   - [ ] **Full Playback** (Subscribers):
     - [ ] Use `ApplicationMusicPlayer` for full track playback.
     - [ ] Convert ShazamKit `appleMusicID` to `MusicItemID` and load `Song`.
@@ -402,9 +404,9 @@ Build an iOS app under the Music Nerd brand that:
 - ✅ Advanced filtering system with enrichment status and date range filtering
 - ⏳ Remaining: UI testing suite, export functionality
 
-**Next:** Complete Phase 6, then Phase 7 (Apple Music Integration) for playback features
+**Next:** Complete Phase 6, then continue Phase 7 (Apple Music Integration) focusing on preview UX polish (progress indicator, denied authorization UX) and full playback scaffolding
 
-**New Phase:** Phase 7 (Apple Music Integration) - 0% complete
+**New Phase:** Phase 7 (Apple Music Integration) - 25% complete
 - 🎵 **Core Value**: Transform TrackNerd from recognition-only to full playback experience
 - 🔑 **Key Features**: Preview playback (non-subscribers), full playback (subscribers)
 - 📱 **Foundation Ready**: ShazamKit already captures `appleMusicID` for seamless integration

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -255,21 +255,22 @@ Build an iOS app under the Music Nerd brand that:
 
 - [ ] **Apple Music Service Layer**:
   - [ ] Create `AppleMusicService` with MusicKit integration providing:
-    - [ ] `requestAuthorization() -> MusicAuthorization.Status`
-    - [ ] `currentSubscription() -> MusicSubscription?`
-    - [ ] `song(fromAppleMusicID:) async throws -> Song?`
-    - [ ] `searchSong(title:artist:) async throws -> Song?` (fallback)
-    - [ ] `previewURL(for:) async throws -> URL?`
-    - [ ] Playback control: `playPreview(url:)`, `playFull(song:)`, `pause()`, `resume()`, `seek(to:)`
+    - [x] `requestAuthorization() -> MusicAuthorization.Status`
+    - [x] `currentSubscription() -> MusicSubscription?`
+    - [x] `song(fromAppleMusicID:) async throws -> Song?`
+    - [x] `searchSong(title:artist:) async throws -> Song?` (fallback)
+    - [x] `previewURL(for:) async throws -> URL?`
+    - [x] Playback control: `playPreview(url:)`, `pause()`, `resume()`
+    - [ ] Playback control: `playFull(song:)`, `seek(to:)`
     - [ ] Observable playback state (isPlaying, position, duration, source: preview/full, current item)
   - [ ] Handle authorization states (denied, authorized, restricted) and subscription capability.
 
 - [ ] **Playback Implementation**:
   - [ ] **Preview Playback** (Non‑subscribers):
-    - [ ] Fetch preview assets using `Song.previewAssets`.
+    - [x] Fetch preview assets using `Song.previewAssets`.
     - [ ] Implement 30‑second preview playback with `AVPlayer` (auto‑stop at 30s).
     - [ ] Handle DRM‑free preview audio streams and errors.
-    - [ ] Preview controls: play/pause and seek (optional seek for MVP).
+    - [x] Preview controls: play/pause (seek optional - deferred).
   - [ ] **Full Playback** (Subscribers):
     - [ ] Use `ApplicationMusicPlayer` for full track playback.
     - [ ] Convert ShazamKit `appleMusicID` to `MusicItemID` and load `Song`.

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -268,7 +268,7 @@ Build an iOS app under the Music Nerd brand that:
 - [ ] **Playback Implementation**:
   - [ ] **Preview Playback** (Non‑subscribers):
     - [x] Fetch preview assets using `Song.previewAssets`.
-    - [ ] Implement 30‑second preview playback with `AVPlayer` (auto‑stop at 30s).
+    - [x] Implement 30‑second preview playback with `AVPlayer` (auto‑stop at 30s).
     - [ ] Handle DRM‑free preview audio streams and errors.
     - [x] Preview controls: play/pause (seek optional - deferred).
   - [ ] **Full Playback** (Subscribers):

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -247,11 +247,11 @@ Build an iOS app under the Music Nerd brand that:
   - Skip upsell flows unless Apple requires; skip analytics and localization.
   - Fallback when `appleMusicID` is missing/unavailable: search by title/artist, if still unavailable, notify user clearly.
 
-- [ ] **MusicKit Framework Setup**:
-  - [ ] Add MusicKit capability and entitlements in project settings.
-  - [ ] Add "Privacy — Media Library Usage Description" to Info.plist.
-  - [ ] Enable Background Modes > Audio and AirPlay.
-  - [ ] Implement MusicKit authorization flow using `MusicAuthorization`.
+- [x] **MusicKit Framework Setup**:
+  - [x] Add MusicKit capability and entitlements in project settings.
+  - [x] Add "Privacy — Media Library Usage Description" to Info.plist.
+  - [x] Enable Background Modes > Audio and AirPlay.
+  - [x] Implement MusicKit authorization flow using `MusicAuthorization`.
 
 - [ ] **Apple Music Service Layer**:
   - [ ] Create `AppleMusicService` with MusicKit integration providing:


### PR DESCRIPTION
## Summary
- Fix preview Play/Pause button not updating by observing `AppleMusicService` directly
- Ensure state is published on main thread by annotating service and protocol with `@MainActor`
- Inject concrete `AppleMusicService` into environment for live SwiftUI updates
- Remove unnecessary Resume button; single control toggles Play/Pause
- Update plan: mark preview playback portions complete; Phase 7 progress to 25%

## Details
- `AppleMusicService` now `@MainActor`; publishes `isPlayingPreview` to drive UI
- `MatchDetailView` binds to `appleMusic.isPlayingPreview` via `@EnvironmentObject`
- 30s auto-stop maintained; AVAudioSession `.playback` configured for previews
- Plan tracks: service layer created, preview playback implemented, live binding noted

## Test plan
- Build and run on iOS Simulator (iPhone SE 3rd gen, iOS 18.2)
- Open a match detail; tap Play Preview
  - Button should switch to Pause immediately
  - After Pause tap, it switches back to Play Preview immediately
  - No background-thread publishing warnings in logs
- Close and reopen detail view: button reflects correct state