### PR TITLE
Phase 7: Full playback MVP, progress UI, and preview fallback

### DIFF
--- a/TrackNerd.xcodeproj/project.pbxproj
+++ b/TrackNerd.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 				INFOPLIST_FILE = TrackNerd/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Music Nerd ID";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Music Nsrd ID uses Apple Music to play previews or full tracks of songs you recognize.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Music Nerd ID uses Apple Music to play song previews and full tracks.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Music Nerd ID needs microphone access to listen to music and identify songs using Shazam technology.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -505,7 +505,7 @@
 				INFOPLIST_FILE = TrackNerd/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Music Nerd ID";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Music Nsrd ID uses Apple Music to play previews or full tracks of songs you recognize.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Music Nerd ID uses Apple Music to play song previews and full tracks.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Music Nerd ID needs microphone access to listen to music and identify songs using Shazam technology.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TrackNerd/Info.plist
+++ b/TrackNerd/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppleMusicUsageDescription</key>
+    <string>Music Nerd ID uses Apple Music to play song previews and full tracks.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/TrackNerd/Services/ShazamService.swift
+++ b/TrackNerd/Services/ShazamService.swift
@@ -116,10 +116,19 @@ class ShazamService: NSObject, ShazamServiceProtocol {
             audioEngine.stop()
         }
         audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.reset()
         
         session = nil
         signatureGenerator = nil
         currentState = .idle
+        
+        // Deactivate audio session to release input and allow other audio to resume
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+            logWithTimestamp("Audio session deactivated after listening")
+        } catch {
+            logWithTimestamp("Failed to deactivate audio session: \(error)")
+        }
     }
     
     // MARK: - Private Methods
@@ -128,7 +137,7 @@ class ShazamService: NSObject, ShazamServiceProtocol {
         logWithTimestamp("Setting up audio session...")
         do {
             let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.record, mode: .measurement, options: [])
+            try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.defaultToSpeaker])
             try audioSession.setActive(true)
             logWithTimestamp("Audio session setup successful")
         } catch {

--- a/TrackNerd/Views/ListeningView.swift
+++ b/TrackNerd/Views/ListeningView.swift
@@ -35,7 +35,7 @@ struct ListeningView: View {
                             .font(.system(size: 80))
                             .foregroundColor(Color.MusicNerd.primary)
                         
-                        Text("What's Playing?")
+                        Text("Hear. ID. Nerd out.")
                             .musicNerdStyle(.displayLarge())
                         
                         Text("Tap to identify any song around you")

--- a/TrackNerdUITests/DesignSystemUITests.swift
+++ b/TrackNerdUITests/DesignSystemUITests.swift
@@ -25,7 +25,7 @@ final class DesignSystemUITests: XCTestCase {
         XCTAssertTrue(tabBar.waitForExistence(timeout: 5.0), "Tab bar should be visible with proper contrast")
         
         // Test that main text in listening view is visible
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0), "Main title should be visible with proper contrast")
         XCTAssertTrue(whatPlayingText.exists, "Text should be present")
     }
@@ -47,7 +47,7 @@ final class DesignSystemUITests: XCTestCase {
         XCTAssertGreaterThan(textElements.count, 0, "Should have text elements with typography applied")
         
         // Test that key text elements are readable and accessible
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0))
         XCTAssertTrue(whatPlayingText.exists, "Main title should be present")
         
@@ -59,7 +59,7 @@ final class DesignSystemUITests: XCTestCase {
     
     func testTextReadability() throws {
         // Test that text elements are properly sized and readable
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0))
         
         // Text should have reasonable frame dimensions
@@ -98,7 +98,7 @@ final class DesignSystemUITests: XCTestCase {
     // MARK: - Spacing and Layout Tests
     func testLayoutSpacing() throws {
         // Test that elements have proper spacing
-        let textElement = app.staticTexts["What's Playing?"]
+        let textElement = app.staticTexts["Hear. ID. Nerd out."]
         let imageElements = app.images["waveform.circle"]
         
         XCTAssertTrue(textElement.waitForExistence(timeout: 5.0))
@@ -117,7 +117,7 @@ final class DesignSystemUITests: XCTestCase {
         let mainWindow = app.windows.firstMatch
         XCTAssertTrue(mainWindow.waitForExistence(timeout: 5.0), "Main window should exist")
         
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0))
         
         let screenFrame = mainWindow.frame
@@ -132,7 +132,7 @@ final class DesignSystemUITests: XCTestCase {
     // MARK: - Accessibility Tests
     func testVoiceOverSupport() throws {
         // Test that elements support VoiceOver
-        let textElement = app.staticTexts["What's Playing?"]
+        let textElement = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(textElement.waitForExistence(timeout: 5.0))
         XCTAssertTrue(textElement.exists, "Text should be present for VoiceOver")
         
@@ -161,7 +161,7 @@ final class DesignSystemUITests: XCTestCase {
         XCTAssertTrue(app.exists)
         
         // Content should still be visible and properly laid out
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0), "Content should be visible in portrait")
         XCTAssertTrue(whatPlayingText.exists, "Content should be present in portrait")
     }
@@ -173,7 +173,7 @@ final class DesignSystemUITests: XCTestCase {
         XCTAssertTrue(app.exists)
         
         // Content should still be visible and properly laid out
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0), "Content should be visible in landscape")
         XCTAssertTrue(whatPlayingText.exists, "Content should be present in landscape")
         
@@ -200,7 +200,7 @@ final class DesignSystemUITests: XCTestCase {
         // For now, test that the app continues to work regardless of system appearance
         XCTAssertTrue(app.exists, "App should work in all appearance modes")
         
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0), "Text should be visible in all appearance modes")
     }
     
@@ -210,7 +210,7 @@ final class DesignSystemUITests: XCTestCase {
         XCTAssertTrue(app.exists)
         
         // Key elements should be present
-        let whatPlayingText = app.staticTexts["What's Playing?"]
+        let whatPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         let waveformImages = app.images["waveform.circle"]
         
         XCTAssertTrue(whatPlayingText.waitForExistence(timeout: 5.0), "Main text should be present")

--- a/TrackNerdUITests/EnrichmentUITests.swift
+++ b/TrackNerdUITests/EnrichmentUITests.swift
@@ -40,7 +40,7 @@ final class EnrichmentUITests: XCTestCase {
         // This validates our Phase 5 implementation without depending on Phase 6 navigation
         
         // Wait for main UI to load
-        let mainHeading = app.staticTexts["What's Playing?"]
+        let mainHeading = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(mainHeading.waitForExistence(timeout: 5.0), "Main UI should load")
         
         // Check that sample matches exist (these will have enrichment data in Phase 6)

--- a/TrackNerdUITests/NetworkStatusUITests.swift
+++ b/TrackNerdUITests/NetworkStatusUITests.swift
@@ -14,7 +14,7 @@ final class NetworkStatusUITests: XCTestCase {
         app.launch()
         
         // Wait for the app to load
-        _ = app.staticTexts["What's Playing?"].waitForExistence(timeout: 5.0)
+        _ = app.staticTexts["Hear. ID. Nerd out."].waitForExistence(timeout: 5.0)
     }
     
     override func tearDownWithError() throws {
@@ -75,7 +75,7 @@ final class NetworkStatusUITests: XCTestCase {
         }
         
         // Core test: UI should remain stable and functional
-        XCTAssertTrue(app.staticTexts["What's Playing?"].exists, "Main UI should remain functional")
+        XCTAssertTrue(app.staticTexts["Hear. ID. Nerd out."].exists, "Main UI should remain functional")
         XCTAssertTrue(app.tabBars.firstMatch.exists, "Navigation should remain functional")
     }
     
@@ -180,7 +180,7 @@ final class NetworkStatusUITests: XCTestCase {
         listeningTab.tap()
         
         // Wait for all UI elements to load
-        let whatIsPlayingText = app.staticTexts["What's Playing?"]
+        let whatIsPlayingText = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(whatIsPlayingText.waitForExistence(timeout: 3.0))
         
         let networkIndicator = app.otherElements["networkStatusIndicator"]
@@ -270,7 +270,7 @@ final class NetworkStatusUITests: XCTestCase {
         }
         
         // Test system resilience: Core UI elements should remain functional
-        XCTAssertTrue(app.staticTexts["What's Playing?"].exists, 
+        XCTAssertTrue(app.staticTexts["Hear. ID. Nerd out."].exists, 
                      "Main UI should remain functional during network indicator lifecycle")
         XCTAssertTrue(app.tabBars.firstMatch.exists, 
                      "Navigation should remain functional during network indicator lifecycle")
@@ -284,7 +284,7 @@ final class NetworkStatusUITests: XCTestCase {
             
             // Return to listening view to verify round-trip navigation
             listeningTab.tap()
-            XCTAssertTrue(app.staticTexts["What's Playing?"].waitForExistence(timeout: 3.0),
+            XCTAssertTrue(app.staticTexts["Hear. ID. Nerd out."].waitForExistence(timeout: 3.0),
                          "Should be able to return to Listen view")
         }
     }
@@ -470,7 +470,7 @@ final class NetworkStatusUITests: XCTestCase {
         listeningTab.tap()
         
         // Use a more generous timeout and check multiple indicators of successful navigation
-        let mainHeading = app.staticTexts["What's Playing?"]
+        let mainHeading = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(mainHeading.waitForExistence(timeout: 5.0), 
                      "Should return to listening view successfully")
         

--- a/TrackNerdUITests/RecognitionFlowUITests.swift
+++ b/TrackNerdUITests/RecognitionFlowUITests.swift
@@ -92,7 +92,7 @@ final class RecognitionFlowUITests: XCTestCase {
     
     func testRecentMatches_showSampleData() throws {
         // Wait for UI to load completely before checking elements
-        let mainHeading = app.staticTexts["What's Playing?"]
+        let mainHeading = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(mainHeading.waitForExistence(timeout: 3.0), "Main UI should load first")
         
         // Check Recent Matches section exists
@@ -115,7 +115,7 @@ final class RecognitionFlowUITests: XCTestCase {
     
     func testListeningViewAccessibility() throws {
         // Wait for UI to fully load
-        let mainHeading = app.staticTexts["What's Playing?"]
+        let mainHeading = app.staticTexts["Hear. ID. Nerd out."]
         XCTAssertTrue(mainHeading.waitForExistence(timeout: 3.0), "Main UI should load")
         
         // Test listen button accessibility (should be interactive when enabled)

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -46,7 +46,7 @@ Build an iOS app under the Music Nerd brand that:
   - [x] Settings view (SettingsView with toggles and preferences)
 - [x] **Base view components with proper accessibility:**
   - [x] TabView navigation with accessibility identifiers
-  - [x] Listening interface with "What's Playing?" UI
+  - [x] Listening interface with "Hear. ID. Nerd out." UI
   - [x] History with search functionality and match cards
   - [x] Settings with toggle controls and sections
 - [x] **Unit Testing:**

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -264,6 +264,7 @@ Build an iOS app under the Music Nerd brand that:
     - [ ] Playback control: `playFull(song:)`, `seek(to:)`
     - [ ] Observable playback state (isPlaying, position, duration, source: preview/full, current item)
     - [x] Publish `isPlayingPreview` for preview play/pause UI
+    - [x] Publish `previewProgress` (0–1) for progress UI
   - [ ] Handle authorization states (denied, authorized, restricted) and subscription capability.
 
 - [ ] **Playback Implementation**:
@@ -273,6 +274,9 @@ Build an iOS app under the Music Nerd brand that:
     - [ ] Handle DRM‑free preview audio streams and errors.
     - [x] Preview controls: play/pause (seek optional - deferred).
     - [x] SwiftUI binding to live playback state via `@EnvironmentObject` service
+    - [x] Progress indicator in `MatchDetailView` bound to `previewProgress`
+    - [x] Denied authorization UX with Settings CTA
+    - [x] Unavailable preview messaging and disabled button state while resolving
   - [ ] **Full Playback** (Subscribers):
     - [ ] Use `ApplicationMusicPlayer` for full track playback.
     - [ ] Convert ShazamKit `appleMusicID` to `MusicItemID` and load `Song`.

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -322,7 +322,7 @@ Build an iOS app under the Music Nerd brand that:
     - AC: Auth prompt appears once; status reflects; denied state includes Settings CTA.
   - [ ] 7.2 Preview playback
     - AC: 30s preview plays with play/pause and progress; resilient to network toggles.
-  - [ ] 7.3 Full playback
+  - [x] 7.3 Full playback
     - AC: Subscribers can play a full track via `ApplicationMusicPlayer`; non‑subs fall back to preview with clear notice.
   - [ ] 7.4 UI integration
     - AC: Controls on `SongMatchCard`; persistent mini‑player functions across tabs; optional Apple Music link if required.

--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -261,11 +261,11 @@ Build an iOS app under the Music Nerd brand that:
     - [x] `searchSong(title:artist:) async throws -> Song?` (fallback)
     - [x] `previewURL(for:) async throws -> URL?`
     - [x] Playback control: `playPreview(url:)`, `pause()`, `resume()`
-    - [ ] Playback control: `playFull(song:)`, `seek(to:)`
-    - [ ] Observable playback state (isPlaying, position, duration, source: preview/full, current item)
-    - [x] Publish `isPlayingPreview` for preview play/pause UI
-    - [x] Publish `previewProgress` (0–1) for progress UI
-  - [ ] Handle authorization states (denied, authorized, restricted) and subscription capability.
+    - [x] Playback control: `playFull(song:)` (MVP)
+    - [ ] Seek support: `seek(to:)`
+    - [ ] Observable playback state (position, duration, source: preview/full, current item)
+    - [x] Publish `isPlayingPreview`, `previewProgress`, `isPlayingFull`, and `fullProgress`
+  - [x] Handle authorization states (denied, authorized, restricted) and subscription capability.
 
 - [ ] **Playback Implementation**:
   - [ ] **Preview Playback** (Non‑subscribers):
@@ -278,9 +278,9 @@ Build an iOS app under the Music Nerd brand that:
     - [x] Denied authorization UX with Settings CTA
     - [x] Unavailable preview messaging and disabled button state while resolving
   - [ ] **Full Playback** (Subscribers):
-    - [ ] Use `ApplicationMusicPlayer` for full track playback.
-    - [ ] Convert ShazamKit `appleMusicID` to `MusicItemID` and load `Song`.
-    - [ ] Single‑item queue for MVP; manage playback states and progress.
+    - [x] Use `ApplicationMusicPlayer` for full track playback (MVP).
+    - [x] Convert ShazamKit `appleMusicID` to `MusicItemID` and load `Song`.
+    - [x] Single‑item queue for MVP; manage playback states and progress (`isPlayingFull`, `fullProgress`).
     - [ ] Configure `AVAudioSession` for `.playback`; handle route changes and interruptions.
 
 - [ ] **UI Integration**:
@@ -290,7 +290,7 @@ Build an iOS app under the Music Nerd brand that:
 
 - [ ] **Subscription Management**:
   - [ ] Reflect subscription status and capability in UI.
-  - [ ] Display appropriate playback options based on subscription status (full vs preview).
+  - [x] Display appropriate playback options based on subscription status in `MatchDetailView` (full vs preview).
   - [ ] Settings surface for managing Apple Music permissions (no upsell in MVP).
 
 - [ ] **Playback Features**:
@@ -399,7 +399,7 @@ Build an iOS app under the Music Nerd brand that:
   - ✅ NetworkStatusUITests: 100% pass rate (17/17 tests)
   - ✅ RecognitionFlowUITests: 100% pass rate after timing fixes
 
-**Currently:** Phase 6 (Data Persistence & History) - 75% complete
+**Currently:** Phase 7 (Apple Music Integration) - in progress (40%)
 - ✅ Complete SwiftData setup with SongMatch and EnrichmentData persistence
 - ✅ Enrichment cache migration to persistent SwiftData storage with expiration
 - ✅ Full history UI implementation with search, filtering, and real-time updates
@@ -408,9 +408,9 @@ Build an iOS app under the Music Nerd brand that:
 - ✅ Advanced filtering system with enrichment status and date range filtering
 - ⏳ Remaining: UI testing suite, export functionality
 
-**Next:** Complete Phase 6, then continue Phase 7 (Apple Music Integration) focusing on preview UX polish (progress indicator, denied authorization UX) and full playback scaffolding
+**Next:** Continue Phase 7 — mini‑player, background/lock‑screen controls, interruption handling, broader UI integration (SongMatchCard controls)
 
-**New Phase:** Phase 7 (Apple Music Integration) - 25% complete
+**New Phase:** Phase 7 (Apple Music Integration) - 40% complete
 - 🎵 **Core Value**: Transform TrackNerd from recognition-only to full playback experience
 - 🔑 **Key Features**: Preview playback (non-subscribers), full playback (subscribers)
 - 📱 **Foundation Ready**: ShazamKit already captures `appleMusicID` for seamless integration


### PR DESCRIPTION
## Summary
- Implement full-track playback (MVP) using `ApplicationMusicPlayer` with progress publishing
- Add preview fallback via iTunes Search when Apple Music preview unavailable
- Show progress bar for full tracks in `MatchDetailView`; unify play/pause control
- Update plan (Phase 7 to 40%, mark AC 7.3 complete, subscription-aware UI)
- Update ListeningView heading to “Hear. ID. Nerd out.” and align UITests

## Test plan
- Build succeeds on simulator
- Preview plays with progress and 30s cutoff
- Full playback path guarded by authorization + subscription; progress visible
- Without subscription, fallback preview plays when Apple preview missing
- UITests adjusted for new heading; manual pass on main flows