### PR TITLE
Chore: raise minimum sample duration to 5s (default 5s)

### DIFF
--- a/TrackNerd/Models/AppSettings.swift
+++ b/TrackNerd/Models/AppSettings.swift
@@ -19,7 +19,9 @@ class AppSettings {
     var sampleDuration: TimeInterval {
         get {
             let saved = userDefaults.double(forKey: Keys.sampleDuration)
-            return saved > 0 ? saved : 3.0 // Default to 3 seconds
+            // Enforce a minimum of 5 seconds and default to 5 if unset
+            let value = saved > 0 ? saved : 5.0
+            return max(value, 5.0)
         }
         set {
             userDefaults.set(newValue, forKey: Keys.sampleDuration)
@@ -93,7 +95,7 @@ class AppSettings {
 
 // MARK: - Sample Duration Options
 extension AppSettings {
-    static let sampleDurationOptions: [TimeInterval] = [3, 5, 10, 15, 20]
+    static let sampleDurationOptions: [TimeInterval] = [5, 10, 15, 20]
     
     static func formatDuration(_ duration: TimeInterval) -> String {
         let seconds = Int(duration)


### PR DESCRIPTION
## Summary
- Set the default recognition sample duration to 5 seconds.
- Enforce a minimum of 5 seconds for saved values.
- Remove 3-second option; available options are now 5, 10, 15, 20.

## Rationale
3s captures felt too short and often delayed matches when additional network time was required. Raising the floor to 5s improves signature quality and reduces early misfires.

## Changes
- `AppSettings.sampleDuration`: default to 5s and coerce values below 5s up to 5s.
- `AppSettings.sampleDurationOptions`: `[5, 10, 15, 20]`.

## Test plan
- Existing users with 3s selected now see 5s in Settings; listening uses 5s.
- New installs default to 5s.
- UI picker shows options 5/10/15/20 only.