### PR TITLE
Add tasks for streaming Shazam recognition

### DIFF
--- a/plans/TrackNerdMVP.md
+++ b/plans/TrackNerdMVP.md
@@ -309,7 +309,14 @@ Build an iOS app under the Music Nerd brand that:
   - [ ] Handle songs not available on Apple Music or region‑restricted.
   - [ ] Fallback when `appleMusicID` is unavailable -> search by title/artist; if not found, notify user.
   - [ ] Offline behavior: disable playback controls with clear messaging; auto‑recover when network returns.
-  - [ ] Network connectivity issues during playback with retry guidance.
+- [ ] Network connectivity issues during playback with retry guidance.
+
+- [ ] **ShazamKit Streaming Refactor**:
+  - [ ] Replace signature-based recognition with `matchStreamingBuffer(_:at:)`.
+  - [ ] Stream audio buffers to `SHSession` directly within the audio tap.
+  - [ ] Remove `SHSignatureGenerator` and related post-capture processing logic.
+  - [ ] Manage recognition lifecycle and timeout handling for streaming.
+  - [ ] Update `ShazamServiceProtocol` and tests for streaming recognition.
 
 - [ ] **Unit Testing:**
   - [ ] Test `AppleMusicService` authorization and subscription checks.


### PR DESCRIPTION
## Summary
- Outline ShazamKit streaming refactor tasks using `matchStreamingBuffer(_:at:)`

## Testing
- `bundle exec fastlane ios test_all` *(fails: uninitialized constant FastlaneCore::UpdateChecker)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bc35915c83249eeea10711c99c8b